### PR TITLE
Change int.Parse to int.TryParse

### DIFF
--- a/goesrecv-monitor/Stats.cs
+++ b/goesrecv-monitor/Stats.cs
@@ -236,7 +236,7 @@ namespace goesrecv_monitor
 
                         if (rsStr != "-1")
                         {
-                            rsErr += int.Parse(rsStr);
+                            int.TryParse(rsStr, out rsErr);
                         }
                     }
                 }


### PR DESCRIPTION
Prevent application crash by bad string passing to int.Parse by using int.TryParse instead.