### PR TITLE
Read nanomsg header and add QPSK mode

### DIFF
--- a/goesrecv-monitor/App.config
+++ b/goesrecv-monitor/App.config
@@ -16,6 +16,9 @@
             <setting name="IP" serializeAs="String">
                 <value>192.168.</value>
             </setting>
+            <setting name="order" serializeAs="String">
+                <value>2</value>
+            </setting>
         </goesrecv_monitor.Properties.Settings>
     </userSettings>
     <applicationSettings>

--- a/goesrecv-monitor/ConstellationPanel.cs
+++ b/goesrecv-monitor/ConstellationPanel.cs
@@ -9,7 +9,7 @@ namespace goesrecv_monitor
     class ConstellationPanel : Panel
     {
         // Globals
-        private List<Point> Symbols;
+        private byte[] Symbols;
         private Brush SymbolBrush;
         private Point Center;
         private Pen LinePen;
@@ -52,12 +52,18 @@ namespace goesrecv_monitor
             // Skip symbols if none provided
             if (Symbols == null) { return; }
 
-            foreach (Point sym in Symbols)
+            for (int i = 8; i < 2048; i = i + 2)
             {
-                // Draw point
-                float sX = Center.X + (sym.X * SymbolScale) - (SymbolSize / 2);
-                float sY = Center.Y + (sym.Y * SymbolScale) - (SymbolSize / 2);
-                g.FillEllipse(SymbolBrush, sX, sY, SymbolSize, SymbolSize);
+                sbyte symI = (sbyte) Symbols[i];
+                sbyte symQ = (sbyte) Symbols[i + 1];
+
+                // Ignore null values
+                if (symI != '\0' && symQ != '\0')
+                {
+                    float sX = Center.X + (symI * SymbolScale) - (SymbolSize / 2);
+                    float sY = Center.Y + (symQ * SymbolScale) - (SymbolSize / 2);
+                    g.FillEllipse(SymbolBrush, sX, sY, SymbolSize, SymbolSize);
+                }
             }
         }
 
@@ -65,7 +71,7 @@ namespace goesrecv_monitor
         /// Draws symbols on the constellation plot
         /// </summary>
         /// <param name="s">List of Point objects representing symbols</param>
-        public void DrawSymbols(List<Point> s)
+        public void DrawSymbols(byte[] s)
         {
             // Set global symbol list
             Symbols = s;
@@ -74,6 +80,9 @@ namespace goesrecv_monitor
             Invalidate();
         }
         
+        /// <summary>
+        /// Draw constellation lines
+        /// </summary>
         protected void DrawLines(Graphics g) {
             // Draw BPSK line
             g.DrawLine(

--- a/goesrecv-monitor/ConstellationPanel.cs
+++ b/goesrecv-monitor/ConstellationPanel.cs
@@ -82,11 +82,15 @@ namespace goesrecv_monitor
                 new Point(Center.X + 1, Height)
             );
 
+            // Skip QPSK line if order is not 4
+            if (Order != 4) { return; }
 
-            // Setup center line variables
-            LineStart = new Point(Center.X + 1, 0);
-            LineEnd = new Point(Center.X + 1, Height);
-            LinePen = new Pen(new SolidBrush(LineColor), 1);
+            // Draw QPSK line
+            g.DrawLine(
+                LinePen,
+                new Point(0, Center.X),
+                new Point(Width, Center.X)
+            );
         }
     }
 }

--- a/goesrecv-monitor/ConstellationPanel.cs
+++ b/goesrecv-monitor/ConstellationPanel.cs
@@ -13,14 +13,13 @@ namespace goesrecv_monitor
         private Brush SymbolBrush;
         private Point Center;
         private Pen LinePen;
-        private Point LineStart;
-        private Point LineEnd;
 
         // Properties
         public Color SymbolColor { get; set; } = Color.FromArgb(128, Color.Yellow);
         public float SymbolScale { get; set; } = 1.75f;
         public int SymbolSize { get; set; } = 5;
         public Color LineColor { get; set; } = Color.DarkSlateGray;
+        public int Order { get; set; } = 2;
 
         /// <summary>
         /// Custom Panel control for drawing BPSK constellation plots
@@ -30,7 +29,9 @@ namespace goesrecv_monitor
             // Stop render flicker by double buffering
             DoubleBuffered = true;
 
+            // Setup brushes and pens
             SymbolBrush = new SolidBrush(SymbolColor);
+            LinePen = new Pen(new SolidBrush(LineColor), 1);
         }
 
         /// <summary>
@@ -42,8 +43,11 @@ namespace goesrecv_monitor
             Graphics g = e.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
 
-            // Draw divider line
-            g.DrawLine(LinePen, LineStart, LineEnd);
+            // Get panel center
+            Center = new Point(Width / 2, Height / 2);
+
+            // Draw symbol dividing lines
+            DrawLines(g);
 
             // Skip symbols if none provided
             if (Symbols == null) { return; }
@@ -69,16 +73,15 @@ namespace goesrecv_monitor
             // Invalidate control, causing it to be re-drawn with OnPaint()
             Invalidate();
         }
+        
+        protected void DrawLines(Graphics g) {
+            // Draw BPSK line
+            g.DrawLine(
+                LinePen,
+                new Point(Center.X + 1, 0),
+                new Point(Center.X + 1, Height)
+            );
 
-        /// <summary>
-        /// Calculates panel center on Resize event
-        /// </summary>
-        protected override void OnResize(EventArgs eventargs)
-        {
-            base.OnResize(eventargs);
-
-            // Get panel center point
-            Center = new Point(Width / 2, Height / 2);
 
             // Setup center line variables
             LineStart = new Point(Center.X + 1, 0);

--- a/goesrecv-monitor/Main.Designer.cs
+++ b/goesrecv-monitor/Main.Designer.cs
@@ -223,11 +223,13 @@
             this.constellationPanel.LineColor = System.Drawing.Color.DarkSlateGray;
             this.constellationPanel.Location = new System.Drawing.Point(0, 0);
             this.constellationPanel.Name = "constellationPanel";
+            this.constellationPanel.Order = 2;
             this.constellationPanel.Size = new System.Drawing.Size(350, 183);
             this.constellationPanel.SymbolColor = System.Drawing.Color.FromArgb(((int)(((byte)(128)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(0)))));
             this.constellationPanel.SymbolScale = 1.75F;
             this.constellationPanel.SymbolSize = 5;
             this.constellationPanel.TabIndex = 16;
+            this.constellationPanel.Click += new System.EventHandler(this.constellationPanel_Click);
             // 
             // labelVersion
             // 

--- a/goesrecv-monitor/Main.cs
+++ b/goesrecv-monitor/Main.cs
@@ -32,6 +32,9 @@ namespace goesrecv_monitor
                 Program.Log(logsrc, "IP: 192.168.");
             }
 
+            // Set constellation order and update UI
+            ChangeOrder(Properties.Settings.Default.order);
+
             // Set control colours
             btnConnct.BackColor = Color.FromArgb(255, 30, 30, 30);
             textIP.BackColor = Color.FromArgb(255, 30, 30, 30);
@@ -184,6 +187,10 @@ namespace goesrecv_monitor
             }
 
             constellationPanel.Invalidate();
+
+            // Save order
+            Properties.Settings.Default.order = order;
+            Properties.Settings.Default.Save();
         }
 
         /// <summary>

--- a/goesrecv-monitor/Main.cs
+++ b/goesrecv-monitor/Main.cs
@@ -158,6 +158,34 @@ namespace goesrecv_monitor
         }
 
         /// <summary>
+        /// Resize UI elements based on constellation order
+        /// </summary>
+        /// <param name="order">Constellation order (2 = BPSK, 4 = QPSK)</param>
+        private void ChangeOrder(int order)
+        {
+            if (order == 2)
+            {
+                // Swap to BPSK
+                constellationPanel.Order = 2;
+                constellationPanel.Height = 184;
+                labelVersion.Location = new Point(2, 167);
+                labelSite.Location = new Point(286, 167);
+                this.Height = 222;
+                constellationPanel.Invalidate();
+            }
+            else
+            {
+                // Swap to QPSK
+                constellationPanel.Order = 4;
+                constellationPanel.Height = 350;
+                labelVersion.Location = new Point(2, 333);
+                labelSite.Location = new Point(286, 333);
+                this.Height = 389;
+            }
+
+            constellationPanel.Invalidate();
+        }
+        /// <summary>
         /// Triggers graceful exit
         /// </summary>
         private void Main_FormClosing(object sender, FormClosingEventArgs e)

--- a/goesrecv-monitor/Main.cs
+++ b/goesrecv-monitor/Main.cs
@@ -191,6 +191,7 @@ namespace goesrecv_monitor
             // Save order
             Properties.Settings.Default.order = order;
             Properties.Settings.Default.Save();
+            Program.Log(logsrc, string.Format("Constellation order: {0} ({1})", order, (order == 2) ? "BPSK" : "QPSK"));
         }
 
         /// <summary>

--- a/goesrecv-monitor/Main.cs
+++ b/goesrecv-monitor/Main.cs
@@ -185,6 +185,22 @@ namespace goesrecv_monitor
 
             constellationPanel.Invalidate();
         }
+
+        /// <summary>
+        /// Swap between BPSK and QPSK mode on Constellation Panel click
+        /// </summary>
+        private void constellationPanel_Click(object sender, EventArgs e)
+        {
+            if (constellationPanel.Order == 4)
+            {
+                ChangeOrder(2);
+            }
+            else
+            {
+                ChangeOrder(4);
+            }
+        }
+
         /// <summary>
         /// Triggers graceful exit
         /// </summary>

--- a/goesrecv-monitor/Main.cs
+++ b/goesrecv-monitor/Main.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Net;

--- a/goesrecv-monitor/Main.cs
+++ b/goesrecv-monitor/Main.cs
@@ -49,17 +49,17 @@ namespace goesrecv_monitor
         /// Draws symbols on constellation plot
         /// </summary>
         /// <param name="points">List of Point objects representing symbols</param>
-        public void DrawSymbols(List<Point> points)
+        public void DrawSymbols(byte[] s)
         {
             if (constellationPanel.InvokeRequired)
             {
                 constellationPanel.Invoke((MethodInvoker)(() => {
-                    constellationPanel.DrawSymbols(points);
+                    constellationPanel.DrawSymbols(s);
                 }));
             }
             else
             {
-                constellationPanel.DrawSymbols(points);
+                constellationPanel.DrawSymbols(s);
             }
         }
 

--- a/goesrecv-monitor/Properties/AssemblyInfo.cs
+++ b/goesrecv-monitor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1")]
-[assembly: AssemblyFileVersion("1.1")]
+[assembly: AssemblyVersion("1.2")]
+[assembly: AssemblyFileVersion("1.2")]

--- a/goesrecv-monitor/Properties/Settings.Designer.cs
+++ b/goesrecv-monitor/Properties/Settings.Designer.cs
@@ -43,5 +43,17 @@ namespace goesrecv_monitor.Properties {
                 return ((bool)(this["logging"]));
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("2")]
+        public int order {
+            get {
+                return ((int)(this["order"]));
+            }
+            set {
+                this["order"] = value;
+            }
+        }
     }
 }

--- a/goesrecv-monitor/Properties/Settings.settings
+++ b/goesrecv-monitor/Properties/Settings.settings
@@ -8,5 +8,8 @@
     <Setting Name="logging" Type="System.Boolean" Scope="Application">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="order" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">2</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/goesrecv-monitor/Stats.cs
+++ b/goesrecv-monitor/Stats.cs
@@ -108,13 +108,6 @@ namespace goesrecv_monitor
                 if (num == 0)
                 {
                     Program.Log(logsrc, "Connection lost/no data, killing thread");
-                
-                    // Reset UI and alert user
-                    Program.MainWindow.ResetUI();
-                    System.Windows.Forms.MessageBox.Show("Lost connection to goesrecv", "Error", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
-
-                    // Stop all threads
-                    Stop();
                     return;
                 }
 

--- a/goesrecv-monitor/Stats.cs
+++ b/goesrecv-monitor/Stats.cs
@@ -94,10 +94,11 @@ namespace goesrecv_monitor
                 return;
             }
 
+            byte[] dres = new byte[256];
+
             // Continually receive data
             while (true)
             {
-                byte[] dres = new byte[5120];
                 int numbytes = s.Receive(dres);
 
                 // Kill thread if no data received
@@ -227,10 +228,11 @@ namespace goesrecv_monitor
                 return;
             }
 
+            byte[] dres = new byte[256];
+
             // Continually receive data
             while (true)
             {
-                byte[] dres = new byte[1024];
                 int numbytes = s.Receive(dres);
 
                 // Kill thread if no data received

--- a/goesrecv-monitor/Stats.cs
+++ b/goesrecv-monitor/Stats.cs
@@ -1,12 +1,9 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace goesrecv_monitor
 {

--- a/goesrecv-monitor/Stats.cs
+++ b/goesrecv-monitor/Stats.cs
@@ -95,17 +95,21 @@ namespace goesrecv_monitor
             }
 
             byte[] dres = new byte[256];
+            int num;
+            JObject json;
 
             // Continually receive data
             while (true)
             {
-                int numbytes = s.Receive(dres);
+                // Receive nanomsg header
+                num = s.Receive(dres, 8, SocketFlags.None);
+
 
                 // Kill thread if no data received
-                if (numbytes == 0)
+                if (num == 0)
                 {
                     Program.Log(logsrc, "Connection lost/no data, killing thread");
-
+                
                     // Reset UI and alert user
                     Program.MainWindow.ResetUI();
                     System.Windows.Forms.MessageBox.Show("Lost connection to goesrecv", "Error", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
@@ -115,55 +119,42 @@ namespace goesrecv_monitor
                     return;
                 }
 
-                string data = Encoding.ASCII.GetString(dres);   // Convert to ASCII;
-                string line;
-                try
+                // Get message length
+                int msglen = dres[7];
+
+                // Receive message content
+                num = s.Receive(dres, msglen, SocketFlags.None);
+
+                // Log message bytes
+                //Program.Log(logsrc, BitConverter.ToString(dres).Replace("-", ""));
+
+                // Kill thread if no data received
+                if (num == 0)
                 {
-                    // Tidy up raw data
-                    data = data.Replace("\0", "");              // Remove null bytes
-                    data = data.Replace("\n", "");              // Remove newlines
-                    data = data.Replace("{{", "{");             // Remove double braces
-                    data = data.Replace("|", "");               // Remove pipes (?)
-
-                    // JSON object substring
-                    line = data.Substring(data.IndexOf('{'), data.IndexOf('}') + 1);
-
-                    // Write cleaned line to log
-                    Program.Log(logsrc, string.Format("OK: {0}", line));
+                    Program.Log(logsrc, "Connection lost/no data, killing thread");
+                    return;
                 }
-                catch (Exception e)
-                {
-                    Program.Log(logsrc, "Error trimming raw data:");
 
-                    // Print exception line-by-line
-                    string[] elines = e.Message.Split('\r');
-                    foreach (string l in elines) {
-                        string ln = l.Replace("\r", "");
-                        ln = ln.Replace("\n", "");
+                // Convert message bytes to ASCII
+                string data = Encoding.ASCII.GetString(dres);
 
-                        Program.Log(logsrc, ln);
-                    }
-
-                    // Write bad line to log
-                    Program.Log(logsrc, string.Format("BAD: {0}", data));
-
-                    // Skip parsing
-                    continue;
-                }
+                // Trim message length and remove trailing new line
+                data = data.Substring(0, msglen);
+                data = data.TrimEnd('\n');
 
                 // Parse JSON objects
-                JObject json;
                 try
                 {
-                    json = JObject.Parse(line);
+                    json = JObject.Parse(data);
+                    Program.Log(logsrc, string.Format("OK: {0}", data));
                 }
                 catch (Newtonsoft.Json.JsonReaderException e)
                 {
-                    Program.Log(logsrc, string.Format("Error parsing JSON: {0}", e.ToString()));
-                    Program.Log(null, line);
+                    Program.Log(logsrc, string.Format("Error parsing JSON: {0}", data));
+                    Program.Log(logsrc, e.ToString());
                     continue;
                 }
-
+                
                 // kHz vs Hz
                 decimal freq = (decimal)json["frequency"];
                 string freqStr;
@@ -180,7 +171,7 @@ namespace goesrecv_monitor
                 }
 
                 // Write parsed data to log
-                Program.Log(null, string.Format("FREQUENCY: {0}", freqStr));
+                Program.Log(null, string.Format("FREQUENCY: {0}\n", freqStr));
 
                 // Update UI
                 Program.MainWindow.FrequencyOffset = freqStr;
@@ -229,75 +220,55 @@ namespace goesrecv_monitor
             }
 
             byte[] dres = new byte[256];
+            int num;
+            JObject json;
 
             // Continually receive data
             while (true)
             {
-                int numbytes = s.Receive(dres);
+                // Receive nanomsg header
+                num = s.Receive(dres, 8, SocketFlags.None);
 
                 // Kill thread if no data received
-                if (numbytes == 0)
+                if (num == 0)
                 {
                     Program.Log(logsrc, "Connection lost/no data, killing thread");
                     return;
                 }
 
-                string data = Encoding.ASCII.GetString(dres);   // Convert to ASCII
-                try
-                {
-                    // Tidy up raw data
-                    data = data.Replace("\0", "");              // Remove null bytes
-                    data = data.Replace("{{", "{");             // Remove double braces
-                    data = data.Replace("|", "");               // Remove pipes (?)
-                    data = data.TrimEnd('\n');                  // Remove trailing newline
+                // Get message length
+                int msglen = dres[7];
 
-                    // Write cleaned line to log
-                    Program.Log(logsrc, string.Format("OK: {0}", data.Replace("\n", "")));
-                }
-                catch (Exception e)
+                // Receive message content
+                num = s.Receive(dres, msglen, SocketFlags.None);
+
+                // Log message bytes
+                //Program.Log(logsrc, BitConverter.ToString(dres).Replace("-", ""));
+
+                // Kill thread if no data received
+                if (num == 0)
                 {
-                    Program.Log(logsrc, string.Format("Error trimming raw data: {0}", e.Message.Replace("\r\n", ": ")));
-                    Program.Log(logsrc, Encoding.ASCII.GetString(dres));
-                    continue;
+                    Program.Log(logsrc, "Connection lost/no data, killing thread");
+                    return;
                 }
 
+                // Convert message bytes to ASCII
+                string data = Encoding.ASCII.GetString(dres);
 
-                // Parse JSON objects
-                List<JObject> json = new List<JObject>();
-                string[] lines = data.Split('\n');
-                string errLine = "";
+                // Trim message length and remove trailing new line
+                data = data.Substring(0, msglen);
+                data = data.TrimEnd('\n');
+                
+                // Parse JSON object
                 try
                 {
-                    // Loop through each JSON line
-                    foreach (string l in lines)
-                    {
-                        // Parse Line
-                        string line = l;
-                        if (line.IndexOf('{') != -1)
-                        {
-                            // Trim leading bytes before JSON string
-                            line = line.Substring(l.IndexOf('{'));
-                        }
-                        else
-                        {
-                            Program.Log(logsrc, "No JSON object found");
-                            continue;
-                        }
-
-                        // Handle double open brace
-                        if (line.StartsWith("{{\""))
-                        {
-                            line = line.Substring(1);
-                        }
-
-                        errLine = line;
-                        json.Add(JObject.Parse(line));
-                    }
+                    json = JObject.Parse(data);
+                    Program.Log(logsrc, string.Format("OK: {0}", data));
                 }
                 catch (Newtonsoft.Json.JsonReaderException e)
                 {
-                    Program.Log(logsrc, string.Format("Error parsing JSON: {0}", e.ToString()));
-                    Program.Log(null, errLine);
+                    Program.Log(logsrc, string.Format("Error parsing JSON: {0}", data));
+                    Program.Log(logsrc, e.ToString());
                     continue;
                 }
 

--- a/goesrecv-monitor/Stats.cs
+++ b/goesrecv-monitor/Stats.cs
@@ -273,45 +273,24 @@ namespace goesrecv_monitor
                 }
 
                 // Signal lock indicator
-                bool locked;
-                if (json[0]["ok"] != null)
-                {
-                    locked = (int)json[0]["ok"] != 0;
-                }
-                else
-                {
-                    locked = false;
-                }
+                bool locked = (json["ok"] != null) ? ((int)json["ok"] != 0) : false;
 
                 // Signal quality
-                int vit = (int)json[0]["viterbi_errors"];
+                int vit = (int)json["viterbi_errors"];
                 float vitLow = 30f;
                 float vitHigh = 1000f;
-                float sigQ;
-                sigQ = 100 - (((vit - vitLow) / (vitHigh - vitLow)) * 100);
+                float sigQ = 100 - (((vit - vitLow) / (vitHigh - vitLow)) * 100);
 
                 // Cap signal quality value
-                if (sigQ > 100)
-                {
-                    sigQ = 100;
-                }
-                else if (sigQ < 0)
-                {
-                    sigQ = 0;
-                }
+                sigQ = (sigQ > 100) ? 100 : sigQ;
+                sigQ = (sigQ < 0) ? 0 : sigQ;
 
-                // Count RS errors
-                int rs = 0;
-                foreach (JObject j in json)
-                {
-                    if ((int)j["reed_solomon_errors"] != -1)
-                    {
-                        rs += (int)j["reed_solomon_errors"];
-                    }
-                }
+                // Reed-Solomon errors
+                int rs = (int)json["reed_solomon_errors"];
+                rs = (rs > 0) ? rs : 0;
 
                 // Write parsed data to log
-                Program.Log(null, string.Format("LOCK: {0}    QUALITY: {1}%    VITERBI: {2}    RS: {3}", locked, sigQ, vit, rs));
+                Program.Log(null, string.Format("LOCK: {0}    QUALITY: {1}%    VITERBI: {2}    RS: {3}\n", locked, sigQ, vit, rs));
 
                 // Update UI
                 Program.MainWindow.SignalLock = locked;

--- a/goesrecv-monitor/Stats.cs
+++ b/goesrecv-monitor/Stats.cs
@@ -174,8 +174,6 @@ namespace goesrecv_monitor
 
                 // Update UI
                 Program.MainWindow.FrequencyOffset = freqStr;
-                
-                Thread.Sleep(500);
             }
         }
 
@@ -296,8 +294,6 @@ namespace goesrecv_monitor
                 Program.MainWindow.SignalQuality = (int)sigQ;
                 Program.MainWindow.ViterbiErrors = vit;
                 Program.MainWindow.RSErrors = rs;
-
-                Thread.Sleep(500);
             }
         }
 

--- a/goesrecv-monitor/Stats.cs
+++ b/goesrecv-monitor/Stats.cs
@@ -104,7 +104,6 @@ namespace goesrecv_monitor
                 // Receive nanomsg header
                 num = s.Receive(dres, 8, SocketFlags.None);
 
-
                 // Kill thread if no data received
                 if (num == 0)
                 {
@@ -171,7 +170,7 @@ namespace goesrecv_monitor
                 }
 
                 // Write parsed data to log
-                Program.Log(null, string.Format("FREQUENCY: {0}\n", freqStr));
+                Program.Log(logsrc, string.Format("FREQUENCY: {0}", freqStr));
 
                 // Update UI
                 Program.MainWindow.FrequencyOffset = freqStr;
@@ -290,7 +289,7 @@ namespace goesrecv_monitor
                 rs = (rs > 0) ? rs : 0;
 
                 // Write parsed data to log
-                Program.Log(null, string.Format("LOCK: {0}    QUALITY: {1}%    VITERBI: {2}    RS: {3}\n", locked, sigQ, vit, rs));
+                Program.Log(logsrc, string.Format("LOCK: {0}    QUALITY: {1}%    VITERBI: {2}    RS: {3}", locked, sigQ, vit, rs));
 
                 // Update UI
                 Program.MainWindow.SignalLock = locked;

--- a/goesrecv-monitor/Symbols.cs
+++ b/goesrecv-monitor/Symbols.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace goesrecv_monitor
 {

--- a/goesrecv-monitor/Symbols.cs
+++ b/goesrecv-monitor/Symbols.cs
@@ -87,6 +87,12 @@ namespace goesrecv_monitor
                 if (num == 0)
                 {
                     Program.Log(logsrc, "Connection lost/no data, killing thread");
+
+                    // Reset UI and alert user
+                    Program.MainWindow.ResetUI();
+                    System.Windows.Forms.MessageBox.Show("Lost connection to goesrecv", "Error", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
+
+                    // Stop all threads
                     Stop();
                     return;
                 }

--- a/goesrecv-monitor/Symbols.cs
+++ b/goesrecv-monitor/Symbols.cs
@@ -118,6 +118,9 @@ namespace goesrecv_monitor
 
         // Properties
         public static string IP { get; set; }
+        
+        // 5001 = Quantisation output   (I only)
+        // 5002 = Clock Recovery output (I and Q)
         static readonly int SymbolPort = 5002;
 
         /// <summary>

--- a/goesrecv-monitor/Symbols.cs
+++ b/goesrecv-monitor/Symbols.cs
@@ -81,9 +81,9 @@ namespace goesrecv_monitor
                 return;
             }
 
+            byte[] dres = new byte[65536];
             while (true)
             {
-                byte[] dres = new byte[65536];
                 int numbytes = s.Receive(dres);
 
                 // Kill thread if no data received

--- a/goesrecv-monitor/Symbols.cs
+++ b/goesrecv-monitor/Symbols.cs
@@ -77,12 +77,14 @@ namespace goesrecv_monitor
             }
 
             byte[] dres = new byte[65536];
+            int num;
             while (true)
             {
-                int numbytes = s.Receive(dres);
+                // Receive message content
+                num = s.Receive(dres);
 
                 // Kill thread if no data received
-                if (numbytes == 0)
+                if (num == 0)
                 {
                     Program.Log(logsrc, "Connection lost/no data, killing thread");
                     Stop();

--- a/goesrecv-monitor/Symbols.cs
+++ b/goesrecv-monitor/Symbols.cs
@@ -94,22 +94,8 @@ namespace goesrecv_monitor
                     return;
                 }
 
-                // Loop through bytes 2 at a time, skipping first 8
-                List<Point> points = new List<Point>();
-                for (int i = 8; i < 2048; i = i + 2)
-                {
-                    sbyte symI = (sbyte) dres[i];
-                    sbyte symQ = (sbyte) dres[i + 1];
-
-                    // Ignore null values
-                    if (symI != '\0' && symQ != '\0')
-                    {
-                        points.Add(new Point(symI, symQ));
-                    }
-                }
-
                 // Update UI
-                Program.MainWindow.DrawSymbols(points);
+                Program.MainWindow.DrawSymbols(dres);
 
                 Thread.Sleep(10);
             }


### PR DESCRIPTION
Reads nanomsg header to get length of JSON strings. QPSK mode added for future QPSK support in [sam210723/goestools](https://github.com/sam210723/goestools) (click constellation to change mode).