### PR TITLE
Parse goesrecv symbols to remove stray nanomsg headers

### DIFF
--- a/goesrecv-monitor/Properties/AssemblyInfo.cs
+++ b/goesrecv-monitor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3")]
-[assembly: AssemblyFileVersion("1.3")]
+[assembly: AssemblyVersion("1.3.1")]
+[assembly: AssemblyFileVersion("1.3.1")]


### PR DESCRIPTION
First off, I want to say a big THANK YOU for writing this program! Its code helped me understand how nanomsg works "on the wire", and I've written a number of goesrecv-related programs thanks to it. So, I wanted to give back.

In goesrecv-monitor v1.3, Symbols.cs is treating the nanomsg TCP stream as a stream of raw symbols. Unfortunately, nanomsg isn't quite that simple. It has 64-bit unsigned integer "headers" throughout the data stream that announce how many bytes are coming next. See section 3 at [https://github.com/nanomsg/nanomsg/blob/master/rfc/sp-tcp-mapping-01.txt](https://github.com/nanomsg/nanomsg/blob/master/rfc/sp-tcp-mapping-01.txt) for more info.

To fix the problem, this PR reads the 64-bit integer (8 bytes), then only draws as many bytes as nanomsg announced is coming. Afterwards, it reads the next 8 bytes as another header (since it must be), and repeats the process.

Admittedly, the constellation diagram does not look that much different on my system, but if others reference your project like I did, this code is a more accurate starting point. 

The code for this is essentially copied and pasted from my own goesbetween project - it's much more necessary to strip out the nanomsg headers when you're pulling the baseband iq samples!